### PR TITLE
Add to comment: Connection to tutorial

### DIFF
--- a/AdtSampleApp/SampleFunctionsApp/ProcessDTRoutedData.cs
+++ b/AdtSampleApp/SampleFunctionsApp/ProcessDTRoutedData.cs
@@ -30,9 +30,12 @@ namespace SampleFunctionsApp
         public static async Task Run([EventGridTrigger] EventGridEvent eventGridEvent, ILogger log)
         {
             log.LogInformation("Start execution");
-            // After this is deployed, you need to turn the Identity Status "On", 
-            // Grab Object Id of the function and assigned "Azure Digital Twins Owner (Preview)" role to this function identity
-            // in order for this function to be authorize on ADT APIs.
+            // After this is deployed, you need to turn the Azure Function Identity Status "On", 
+            // grab Object ID of the function, and assign "Azure Digital Twins Owner (Preview)" role to this function identity
+            // in order for this function to be authorized on ADT APIs.
+            //
+            // If you are following "Tutorial: Connect an end-to-end solution" in the Azure Digital Twins documentation, you have done this already
+            // in the "Assign permissions to the function app" section.
 
             DigitalTwinsClient client;
             // Authenticate on ADT APIs


### PR DESCRIPTION
Adding additional context to a comment, to resolve documentation bug [#8301350](https://msazure.visualstudio.com/One/_workitems/edit/8301350).

Bug was filed because a reader going through the [end-to-end tutorial](https://docs.microsoft.com/azure/digital-twins/tutorial-end-to-end) encountered the comment on line 33 of ProcessDTRoutedData instructing them to enable identity and assign the Azure Digital Twins Owner (Preview) role to the function, and they didn't realize they had already done this with a previous step in the tutorial.

To resolve this confusion, adding a note that says "If you're working through the end-to-end tutorial, you've already taken care of this."