### PR TITLE
Fixed propagation of digital twin events through the graph

### DIFF
--- a/AdtSampleApp/SampleFunctionsApp/AdtUtilities.cs
+++ b/AdtSampleApp/SampleFunctionsApp/AdtUtilities.cs
@@ -57,7 +57,7 @@ namespace SampleFunctionsApp
             try
             {
                 var updateTwinData = new JsonPatchDocument();
-                updateTwinData.AppendAdd(propertyPath, value);
+                updateTwinData.AppendReplace(propertyPath, value);
 
                 log.LogInformation($"UpdateTwinPropertyAsync sending {updateTwinData}");
                 await client.UpdateDigitalTwinAsync(twinId, updateTwinData);

--- a/AdtSampleApp/SampleFunctionsApp/ProcessHubToDTEvents.cs
+++ b/AdtSampleApp/SampleFunctionsApp/ProcessHubToDTEvents.cs
@@ -47,7 +47,7 @@ namespace SampleFunctionsApp
 
                 //Update twin using device temperature
                 var updateTwinData = new JsonPatchDocument();
-                updateTwinData.AppendAdd("/Temperature", temperature.Value<double>());
+                updateTwinData.AppendReplace("/Temperature", temperature.Value<double>());
                 await client.UpdateDigitalTwinAsync(deviceId, updateTwinData);
             }
         }


### PR DESCRIPTION
The `ProcessDTRoutedData` function [expects](https://github.com/Azure-Samples/digital-twins-samples/blob/b90d184d16458ffd525156df010336e4406483d7/AdtSampleApp/SampleFunctionsApp/ProcessDTRoutedData.cs#L69) the twin operation to be `replace`, however, both updates are made with the `add` operation. The [Propagate Azure Digital Twins events through the graph](https://docs.microsoft.com/en-us/azure/digital-twins/tutorial-end-to-end#propagate-azure-digital-twins-events-through-the-graph) subsection of the end-to-end tutorial won't work as an outcome. This PR addresses the issue and makes the sample work as expected.

Resolves issue #43.