### PR TITLE
Update ProcessHubToDTEvents.cs

### DIFF
--- a/AdtSampleApp/SampleFunctionsApp/ProcessHubToDTEvents.cs
+++ b/AdtSampleApp/SampleFunctionsApp/ProcessHubToDTEvents.cs
@@ -48,7 +48,7 @@ namespace SampleFunctionsApp
                 //Update twin using device temperature
                 var updateTwinData = new JsonPatchDocument();
                 updateTwinData.AppendReplace("/Temperature", temperature.Value<double>());
-                await client.UpdateDigitalTwinAsync(deviceId, updateTwinData);
+                await client.PublishTelemetryAsync(deviceId, Guid.NewGuid().ToString(), updateTwinData.ToString());
             }
         }
     }


### PR DESCRIPTION
Change Update to Telemetry update vs Lifecycle Property Update as this is Telemetry data.

This ends up causing issues because the "telemetry updates" end up getting classified as "Microsoft.DigitalTwins.Twin.Update" events instead of "Telemetry" messages.  