### PR TITLE
ADT Freshness - TargetFramework updated

### DIFF
--- a/AdtSampleApp/SampleClientApp/SampleClientApp.csproj
+++ b/AdtSampleApp/SampleClientApp/SampleClientApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>SampleClientApp</AssemblyName>
     <RootNamespace>SampleClientApp</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/AdtSampleApp/SampleClientApp/SampleClientApp.csproj
+++ b/AdtSampleApp/SampleClientApp/SampleClientApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>SampleClientApp</AssemblyName>
     <RootNamespace>SampleClientApp</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/AdtSampleApp/SampleFunctionsApp/SampleFunctionsApp.csproj
+++ b/AdtSampleApp/SampleFunctionsApp/SampleFunctionsApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enabled</ImplicitUsings>

--- a/AdtSampleApp/SampleFunctionsApp/SampleFunctionsApp.csproj
+++ b/AdtSampleApp/SampleFunctionsApp/SampleFunctionsApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enabled</ImplicitUsings>

--- a/DeviceSimulator/DeviceSimulator/DeviceSimulator.csproj
+++ b/DeviceSimulator/DeviceSimulator/DeviceSimulator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>DeviceSimulator</AssemblyName>
     <RootNamespace>DeviceSimulator</RootNamespace>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
`TargetFramework` value in .csproj files for all three projects under `/AdtSampleApp` updated to `net8.0`, for Azure (and `AzureFunctionsVersion`) compatibility. No other packages appear to be affected.